### PR TITLE
Fix/adjust unsorted insertion on filter data

### DIFF
--- a/src/nodes/filterDataNode.js
+++ b/src/nodes/filterDataNode.js
@@ -73,7 +73,7 @@ class FilterDataNode extends Nodes.SystemTaskNode {
     try {
       logger.debug("filterData Node running");
       const [is_valid, validation_errors] = FilterDataNode.validateExecutionData(executionData);
-      if (!is_valid) {
+      if(!is_valid){
         const errors = JSON.parse(validation_errors).map((err) => `field '${err.instancePath}' ${err.message}`);
         throw JSON.stringify(errors);
       }

--- a/src/nodes/filterDataNode.js
+++ b/src/nodes/filterDataNode.js
@@ -72,8 +72,8 @@ class FilterDataNode extends Nodes.SystemTaskNode {
   async _run(executionData) {
     try {
       logger.debug("filterData Node running");
-      const  [is_valid, validation_errors] = FilterDataNode.validateExecutionData(executionData);
-      if(!is_valid){
+      const [is_valid, validation_errors] = FilterDataNode.validateExecutionData(executionData);
+      if (!is_valid) {
         const errors = JSON.parse(validation_errors).map((err) => `field '${err.instancePath}' ${err.message}`);
         throw JSON.stringify(errors);
       }
@@ -86,22 +86,32 @@ class FilterDataNode extends Nodes.SystemTaskNode {
       });
 
       data.forEach((items) => {
-        keys.forEach((key) => {
-          primary_keys[key].forEach((valueKey) => {
+        let resultKey
+        let validatorKeys = keys.some((key) => {
+          let validatorPrimaryKeys = primary_keys[key].some((valueKey) => {
             let arr = [];
             let keys = Object.keys(valueKey);
-
             keys.forEach((key) => {
               arr.push(valueKey[key] === items[key])
             });
-
             if (arr.every((b) => b)) {
-              result[key].push(items)
+              resultKey = key
+              return true
             } else {
-              result.unsorted.push(items)
+              return false
             }
-          })
+          });
+          if (validatorPrimaryKeys) {
+            return true
+          } else {
+            return false
+          }
         });
+        if (validatorKeys) {
+          result[resultKey].push(items)
+        } else {
+          result.unsorted.push(items)
+        }
       });
 
       return [{ data: result }, ProcessStatus.RUNNING];

--- a/src/nodes/filterDataNode.js
+++ b/src/nodes/filterDataNode.js
@@ -101,11 +101,7 @@ class FilterDataNode extends Nodes.SystemTaskNode {
               return false
             }
           });
-          if (validatorPrimaryKeys) {
-            return true
-          } else {
-            return false
-          }
+          return validatorPrimaryKeys
         });
         if (validatorKeys) {
           result[resultKey].push(items)


### PR DESCRIPTION
Durante os testes locais na API foi identificado que o unsorted estava sendo iterado em cada laço. 

Removemos a inserção de incorreta de objetos para dentro do unsorted.

Com mudança não haverá repetição de propriedades do primary_keys.


Input: 
![PayloadInput](https://user-images.githubusercontent.com/63261859/209877374-7229d493-fab8-4407-a071-b81cef10a5d2.png)

Output:
![PayloadOutputt](https://user-images.githubusercontent.com/63261859/209877538-176adbfe-9b66-475c-bcf4-f3d7e45ccb57.png)

