### PR TITLE
Add timer management routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ Add a .env file with the following variables:
 
 ### TOKEN CONFIGURATION
 
+The default configuration is set to use a own generated JWT token.
+If an external token is to be used, the JWT_ variables need to be passed. 
+
 - JWT_KEY (default=*1234*)
 - JWT_ALG (default=*HS256*, if set to RS256, the application will convert the JWT_KEY to a public certificate.)
 - JWT_PASSTHROUGH (boolean, default=*true*)
@@ -76,7 +79,20 @@ Add a .env file with the following variables:
 - TIMER_BATCH (integer, default=*40*)
 - ORPHAN_BATCH (integer, default=*40*)
 
+#### TIMER CONFIGURATION
+
+Timer management can be handled outside the heartbeat, by a external Timer Worker running timers using an Redis Queue using bullMQ. 
+To enable this option, the engine must be configured to publish timers on the queue thru 3 variables that configures the bullMQ.
+
+- TIMER_QUEUE (string)
+- TIMER_HOST (URL)
+- TIMER_PORT
+
 ### HEALTHCHECK
+
+Healthcheck route (GET / or GET /healthcheck), by default, checks the router and db connection.
+The server can be configured to evaluate the number of ready timers (timers expired but not yet triggered) to access engine health.
+This setting should not be enabled if the timers area being handled by the timer worker.
 
 - MAX_READY_TIMERS (_optional_, integer, defines the amount of ready timers before the server is declared unhealthy)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,3 +50,10 @@ services:
   #   ports:
   #     - 5672:5672
   #     - 15672:15672
+
+  redis:
+    image: redis:7-bullseye
+    container_name: flowbuild_redis
+    restart: always
+    ports:
+      - 6379:6379

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.20.2",
       "license": "MIT",
       "dependencies": {
-        "@flowbuild/engine": "2.22.2",
+        "@flowbuild/engine": "2.24.2",
         "@flowbuild/indexer": "1.0.2",
         "@flowbuild/nodejs-diagram-builder": "1.1.0",
         "@flowbuild/process-tree": "1.0.4",
@@ -28,14 +28,14 @@
         "ajv-formats": "2.1.1",
         "amqplib": "0.10.3",
         "async-mqtt": "2.6.3",
-        "axios": "1.3.3",
+        "axios": "1.3.4",
         "dotenv": "16.0.3",
         "grpc-client-promise-wrapper": "1.0.5",
         "grpc-reflection-js": "0.1.2",
-        "jsrsasign": "10.6.1",
+        "jsrsasign": "10.7.0",
         "knex": "2.4.2",
         "koa": "2.14.1",
-        "koa-bodyparser": "4.3.0",
+        "koa-bodyparser": "4.4.0",
         "koa-compose": "4.1.0",
         "koa-helmet": "6.1.0",
         "koa-jwt": "4.0.4",
@@ -46,14 +46,14 @@
         "koa2-cors": "2.0.6",
         "lodash": "4.17.21",
         "nanoid": "3.3.4",
-        "newrelic": "9.10.2",
-        "npm": "9.6.0",
-        "pg": "8.9.0",
+        "newrelic": "9.13.0",
+        "npm": "9.6.2",
+        "pg": "8.10.0",
         "raw-body": "2.5.2",
         "swagger-ui-dist": "4.17.0",
         "uuid": "8.3.2",
         "winston": "3.8.2",
-        "ws": "8.12.1"
+        "ws": "8.13.0"
       },
       "devDependencies": {
         "@semantic-release/changelog": "6.0.2",
@@ -718,9 +718,9 @@
       }
     },
     "node_modules/@flowbuild/engine": {
-      "version": "2.22.2",
-      "resolved": "https://registry.npmjs.org/@flowbuild/engine/-/engine-2.22.2.tgz",
-      "integrity": "sha512-bOSRZi3NYdqtHUz2D4DaXsXdvd4t5EUFa7VuhsrCrf+IWPaq8hyZcsQFC7j7Jt0eLwa83c3Hka0eAvKsqg/hGw==",
+      "version": "2.24.2",
+      "resolved": "https://registry.npmjs.org/@flowbuild/engine/-/engine-2.24.2.tgz",
+      "integrity": "sha512-fGJJvg4/FFSlKbWpZ4LVBgTsyz7vpJFtzMeJVXQvFoPBFkBrmcEOEtnhilf4DcjQ9T/auaoXGoeVDY9TiPwl+Q==",
       "dependencies": {
         "ajv": "8.12.0",
         "ajv-formats": "2.1.1",
@@ -751,6 +751,31 @@
       "dependencies": {
         "follow-redirects": "^1.14.9",
         "form-data": "^4.0.0"
+      }
+    },
+    "node_modules/@flowbuild/engine/node_modules/pg": {
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.9.0.tgz",
+      "integrity": "sha512-ZJM+qkEbtOHRuXjmvBtOgNOXOtLSbxiMiUVMgE4rV6Zwocy03RicCVvDXgx8l4Biwo8/qORUnEqn2fdQzV7KCg==",
+      "dependencies": {
+        "buffer-writer": "2.0.0",
+        "packet-reader": "1.0.0",
+        "pg-connection-string": "^2.5.0",
+        "pg-pool": "^3.5.2",
+        "pg-protocol": "^1.6.0",
+        "pg-types": "^2.1.0",
+        "pgpass": "1.x"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
       }
     },
     "node_modules/@flowbuild/indexer": {
@@ -840,6 +865,31 @@
         "pg": "8.9.0",
         "uuid": "9.0.0",
         "winston": "3.8.2"
+      }
+    },
+    "node_modules/@flowbuild/process-tree/node_modules/pg": {
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.9.0.tgz",
+      "integrity": "sha512-ZJM+qkEbtOHRuXjmvBtOgNOXOtLSbxiMiUVMgE4rV6Zwocy03RicCVvDXgx8l4Biwo8/qORUnEqn2fdQzV7KCg==",
+      "dependencies": {
+        "buffer-writer": "2.0.0",
+        "packet-reader": "1.0.0",
+        "pg-connection-string": "^2.5.0",
+        "pg-pool": "^3.5.2",
+        "pg-protocol": "^1.6.0",
+        "pg-types": "^2.1.0",
+        "pgpass": "1.x"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
       }
     },
     "node_modules/@flowbuild/process-tree/node_modules/uuid": {
@@ -6172,8 +6222,7 @@
     "node_modules/abbrev": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
-      "dev": true
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
     },
     "node_modules/accepts": {
       "version": "1.3.7",
@@ -6446,9 +6495,9 @@
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "node_modules/axios": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.3.3.tgz",
-      "integrity": "sha512-eYq77dYIFS77AQlhzEL937yUBSepBfPIe8FcgEDN35vMNZKMrs81pgnyrQpwfy4NF4b4XWX1Zgx7yX+25w8QJA==",
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.3.4.tgz",
+      "integrity": "sha512-toYm+Bsyl6VC5wSkfkbbNB6ROv7KY93PEBBL6xyDczaIHasAiv4wPqQ/c4RjoQzipxRD2W5g21cOqQulZ7rHwQ==",
       "dependencies": {
         "follow-redirects": "^1.15.0",
         "form-data": "^4.0.0",
@@ -6999,7 +7048,6 @@
       "version": "3.8.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.8.0.tgz",
       "integrity": "sha512-eXTggHWSooYhq49F2opQhuHWgzucfF2YgODK4e1566GQs5BIfP30B0oenwBJHfWxAs2fyPB1s7Mg949zLf61Yw==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -9092,7 +9140,6 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
-      "dev": true,
       "engines": {
         "node": ">=0.8.19"
       }
@@ -9130,8 +9177,7 @@
     "node_modules/ini": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
-      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
-      "dev": true
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
     },
     "node_modules/interpret": {
       "version": "2.2.0",
@@ -10476,9 +10522,9 @@
       }
     },
     "node_modules/jsrsasign": {
-      "version": "10.6.1",
-      "resolved": "https://registry.npmjs.org/jsrsasign/-/jsrsasign-10.6.1.tgz",
-      "integrity": "sha512-emiQ05haY9CRj1Ho/LiuCqr/+8RgJuWdiHYNglIg2Qjfz0n+pnUq9I2QHplXuOMO2EnAW1oCGC1++aU5VoWSlw==",
+      "version": "10.7.0",
+      "resolved": "https://registry.npmjs.org/jsrsasign/-/jsrsasign-10.7.0.tgz",
+      "integrity": "sha512-D5V2gGpYGtwbAtQHoglTVrpYf7QJuNoPEhaLOsTFONS2jXUl3qyR1hnYrNpASAybqQeiDYA3zGthR0ubgPRoQA==",
       "funding": {
         "url": "https://github.com/kjur/jsrsasign#donations"
       }
@@ -10620,9 +10666,9 @@
       }
     },
     "node_modules/koa-bodyparser": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/koa-bodyparser/-/koa-bodyparser-4.3.0.tgz",
-      "integrity": "sha512-uyV8G29KAGwZc4q/0WUAjH+Tsmuv9ImfBUF2oZVyZtaeo0husInagyn/JH85xMSxM0hEk/mbCII5ubLDuqW/Rw==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/koa-bodyparser/-/koa-bodyparser-4.4.0.tgz",
+      "integrity": "sha512-AXPY7wwKZUmbgb8VkTEUFoRNOlx6aWRJwEnQD+zfNf33/7KSAkN4Oo9BqlIk80D+5TvuqlhpQT5dPVcyxl5Zsw==",
       "dependencies": {
         "co-body": "^6.0.0",
         "copy-to": "^2.0.1"
@@ -11519,12 +11565,12 @@
       "dev": true
     },
     "node_modules/newrelic": {
-      "version": "9.10.2",
-      "resolved": "https://registry.npmjs.org/newrelic/-/newrelic-9.10.2.tgz",
-      "integrity": "sha512-kVRLwlT3/TK1B/zWAHaaJngubPeEEOhKyGXhBTrOjhQ8X44Trz/XsndlgyY30FtvM3upxCSDuOdbqOHd7DOEVg==",
+      "version": "9.13.0",
+      "resolved": "https://registry.npmjs.org/newrelic/-/newrelic-9.13.0.tgz",
+      "integrity": "sha512-wJfmtNH7T0IzfQ/6L9KWZW/kcRNHXrWGUARiekhdAGv/nBOO49OBP6VBQwhaTKk84yyMt0qevExYtutrmfuE3w==",
       "dependencies": {
-        "@grpc/grpc-js": "^1.8.7",
-        "@grpc/proto-loader": "^0.7.4",
+        "@grpc/grpc-js": "^1.8.10",
+        "@grpc/proto-loader": "^0.7.5",
         "@newrelic/aws-sdk": "^5.0.2",
         "@newrelic/koa": "^7.1.1",
         "@newrelic/superagent": "^6.0.0",
@@ -11533,7 +11579,7 @@
         "https-proxy-agent": "^5.0.0",
         "json-bigint": "^1.0.0",
         "json-stringify-safe": "^5.0.0",
-        "readable-stream": "^3.6.0",
+        "readable-stream": "^3.6.1",
         "semver": "^5.3.0",
         "winston-transport": "^4.5.0"
       },
@@ -11712,7 +11758,6 @@
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
       "integrity": "sha1-bd0hvSoxQXuScn3Vhfim83YI6+4=",
-      "dev": true,
       "dependencies": {
         "abbrev": "1"
       },
@@ -11766,9 +11811,9 @@
       }
     },
     "node_modules/npm": {
-      "version": "9.6.0",
-      "resolved": "https://registry.npmjs.org/npm/-/npm-9.6.0.tgz",
-      "integrity": "sha512-BE7ZFIXSg5iiSrrFvcEDqZuCynfkKjIiLjq3vFgpogu0eMb7S6LUYSUPsSMp4m5ORRme7zDCRnaBdCWrxU3mVg==",
+      "version": "9.6.2",
+      "resolved": "https://registry.npmjs.org/npm/-/npm-9.6.2.tgz",
+      "integrity": "sha512-TnXoXhlFkH/9wI4+aXSq0aPLwKG7Ge17t1ME4/rQt+0DZWQCRk9PwhBuX/shqdUiHeKicSLSkzWx+QZgTRE+/A==",
       "bundleDependencies": [
         "@isaacs/string-locale-compare",
         "@npmcli/arborist",
@@ -11839,8 +11884,8 @@
       ],
       "dependencies": {
         "@isaacs/string-locale-compare": "^1.1.0",
-        "@npmcli/arborist": "^6.2.4",
-        "@npmcli/config": "^6.1.3",
+        "@npmcli/arborist": "^6.2.5",
+        "@npmcli/config": "^6.1.4",
         "@npmcli/map-workspaces": "^3.0.2",
         "@npmcli/package-json": "^3.0.0",
         "@npmcli/run-script": "^6.0.0",
@@ -11862,19 +11907,19 @@
         "is-cidr": "^4.0.2",
         "json-parse-even-better-errors": "^3.0.0",
         "libnpmaccess": "^7.0.2",
-        "libnpmdiff": "^5.0.12",
-        "libnpmexec": "^5.0.12",
-        "libnpmfund": "^4.0.12",
+        "libnpmdiff": "^5.0.13",
+        "libnpmexec": "^5.0.13",
+        "libnpmfund": "^4.0.13",
         "libnpmhook": "^9.0.3",
         "libnpmorg": "^5.0.3",
-        "libnpmpack": "^5.0.12",
-        "libnpmpublish": "^7.1.0",
+        "libnpmpack": "^5.0.13",
+        "libnpmpublish": "^7.1.2",
         "libnpmsearch": "^6.0.2",
         "libnpmteam": "^5.0.3",
         "libnpmversion": "^4.0.2",
         "make-fetch-happen": "^11.0.3",
         "minimatch": "^6.2.0",
-        "minipass": "^4.0.3",
+        "minipass": "^4.2.4",
         "minipass-pipeline": "^1.2.4",
         "ms": "^2.1.2",
         "node-gyp": "^9.3.1",
@@ -11945,7 +11990,7 @@
       "license": "ISC"
     },
     "node_modules/npm/node_modules/@npmcli/arborist": {
-      "version": "6.2.4",
+      "version": "6.2.5",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -11991,7 +12036,7 @@
       }
     },
     "node_modules/npm/node_modules/@npmcli/config": {
-      "version": "6.1.3",
+      "version": "6.1.4",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -12167,12 +12212,31 @@
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
+    "node_modules/npm/node_modules/@sigstore/protobuf-specs": {
+      "version": "0.1.0",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
     "node_modules/npm/node_modules/@tootallnate/once": {
       "version": "2.0.0",
       "inBundle": true,
       "license": "MIT",
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/npm/node_modules/@tufjs/models": {
+      "version": "1.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimatch": "^6.1.0"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/npm/node_modules/abbrev": {
@@ -12206,12 +12270,12 @@
       }
     },
     "node_modules/npm/node_modules/agentkeepalive": {
-      "version": "4.2.1",
+      "version": "4.3.0",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "debug": "^4.1.0",
-        "depd": "^1.1.2",
+        "depd": "^2.0.0",
         "humanize-ms": "^1.2.1"
       },
       "engines": {
@@ -12580,11 +12644,11 @@
       "license": "MIT"
     },
     "node_modules/npm/node_modules/depd": {
-      "version": "1.1.2",
+      "version": "2.0.0",
       "inBundle": true,
       "license": "MIT",
       "engines": {
-        "node": ">= 0.6"
+        "node": ">= 0.8"
       }
     },
     "node_modules/npm/node_modules/diff": {
@@ -12994,11 +13058,11 @@
       }
     },
     "node_modules/npm/node_modules/libnpmdiff": {
-      "version": "5.0.12",
+      "version": "5.0.13",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^6.2.4",
+        "@npmcli/arborist": "^6.2.5",
         "@npmcli/disparity-colors": "^3.0.0",
         "@npmcli/installed-package-contents": "^2.0.2",
         "binary-extensions": "^2.2.0",
@@ -13013,11 +13077,11 @@
       }
     },
     "node_modules/npm/node_modules/libnpmexec": {
-      "version": "5.0.12",
+      "version": "5.0.13",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^6.2.4",
+        "@npmcli/arborist": "^6.2.5",
         "@npmcli/run-script": "^6.0.0",
         "chalk": "^4.1.0",
         "ci-info": "^3.7.1",
@@ -13035,11 +13099,11 @@
       }
     },
     "node_modules/npm/node_modules/libnpmfund": {
-      "version": "4.0.12",
+      "version": "4.0.13",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^6.2.4"
+        "@npmcli/arborist": "^6.2.5"
       },
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
@@ -13070,11 +13134,11 @@
       }
     },
     "node_modules/npm/node_modules/libnpmpack": {
-      "version": "5.0.12",
+      "version": "5.0.13",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^6.2.4",
+        "@npmcli/arborist": "^6.2.5",
         "@npmcli/run-script": "^6.0.0",
         "npm-package-arg": "^10.1.0",
         "pacote": "^15.0.8"
@@ -13084,7 +13148,7 @@
       }
     },
     "node_modules/npm/node_modules/libnpmpublish": {
-      "version": "7.1.0",
+      "version": "7.1.2",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -13092,6 +13156,7 @@
         "normalize-package-data": "^5.0.0",
         "npm-package-arg": "^10.1.0",
         "npm-registry-fetch": "^14.0.3",
+        "proc-log": "^3.0.0",
         "semver": "^7.3.7",
         "sigstore": "^1.0.0",
         "ssri": "^10.0.1"
@@ -13139,7 +13204,7 @@
       }
     },
     "node_modules/npm/node_modules/lru-cache": {
-      "version": "7.16.2",
+      "version": "7.18.3",
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -13186,7 +13251,7 @@
       }
     },
     "node_modules/npm/node_modules/minipass": {
-      "version": "4.0.3",
+      "version": "4.2.4",
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -13639,7 +13704,7 @@
       }
     },
     "node_modules/npm/node_modules/node-gyp/node_modules/readable-stream": {
-      "version": "3.6.0",
+      "version": "3.6.1",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -14177,10 +14242,11 @@
       "license": "ISC"
     },
     "node_modules/npm/node_modules/sigstore": {
-      "version": "1.0.0",
+      "version": "1.1.1",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
+        "@sigstore/protobuf-specs": "^0.1.0",
         "make-fetch-happen": "^11.0.1",
         "tuf-js": "^1.0.0"
       },
@@ -14227,7 +14293,7 @@
       }
     },
     "node_modules/npm/node_modules/spdx-correct": {
-      "version": "3.1.1",
+      "version": "3.2.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -14365,12 +14431,12 @@
       }
     },
     "node_modules/npm/node_modules/tuf-js": {
-      "version": "1.0.0",
+      "version": "1.1.1",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "make-fetch-happen": "^11.0.1",
-        "minimatch": "^6.1.0"
+        "@tufjs/models": "1.0.0",
+        "make-fetch-happen": "^11.0.1"
       },
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
@@ -14787,14 +14853,14 @@
       }
     },
     "node_modules/pg": {
-      "version": "8.9.0",
-      "resolved": "https://registry.npmjs.org/pg/-/pg-8.9.0.tgz",
-      "integrity": "sha512-ZJM+qkEbtOHRuXjmvBtOgNOXOtLSbxiMiUVMgE4rV6Zwocy03RicCVvDXgx8l4Biwo8/qORUnEqn2fdQzV7KCg==",
+      "version": "8.10.0",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.10.0.tgz",
+      "integrity": "sha512-ke7o7qSTMb47iwzOSaZMfeR7xToFdkE71ifIipOAAaLIM0DYzfOAXlgFFmYUIE2BcJtvnVlGCID84ZzCegE8CQ==",
       "dependencies": {
         "buffer-writer": "2.0.0",
         "packet-reader": "1.0.0",
         "pg-connection-string": "^2.5.0",
-        "pg-pool": "^3.5.2",
+        "pg-pool": "^3.6.0",
         "pg-protocol": "^1.6.0",
         "pg-types": "^2.1.0",
         "pgpass": "1.x"
@@ -14825,9 +14891,9 @@
       }
     },
     "node_modules/pg-pool": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.5.2.tgz",
-      "integrity": "sha512-His3Fh17Z4eg7oANLob6ZvH8xIVen3phEZh2QuyrIl4dQSDVEabNducv6ysROKpDNPSD+12tONZVWfSgMvDD9w==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.6.0.tgz",
+      "integrity": "sha512-clFRf2ksqd+F497kWFyM21tMjeikn60oGDmqMT8UBrynEwVEX/5R5xd2sdvdo1cZCFlguORNpVuqxIj+aK4cfQ==",
       "peerDependencies": {
         "pg": ">=8.0"
       }
@@ -15317,9 +15383,9 @@
       }
     },
     "node_modules/readable-stream": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
       "dependencies": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -15846,8 +15912,7 @@
     "node_modules/signal-exit": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-      "dev": true
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="
     },
     "node_modules/signale": {
       "version": "1.4.0",
@@ -16797,7 +16862,6 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-4.0.2.tgz",
       "integrity": "sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg==",
-      "dev": true,
       "dependencies": {
         "imurmurhash": "^0.1.4",
         "signal-exit": "^3.0.7"
@@ -16807,9 +16871,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.12.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.12.1.tgz",
-      "integrity": "sha512-1qo+M9Ba+xNhPB+YTWUlK6M17brTut5EXbcBaMRN5pH5dFrXz7lzz1ChFSUq3bOUl8yEvSenhHmYUNJxFzdJew==",
+      "version": "8.13.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
+      "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
       "engines": {
         "node": ">=10.0.0"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.20.2",
       "license": "MIT",
       "dependencies": {
-        "@flowbuild/engine": "2.24.2",
+        "@flowbuild/engine": "2.24.3",
         "@flowbuild/indexer": "1.0.2",
         "@flowbuild/nodejs-diagram-builder": "1.1.0",
         "@flowbuild/process-tree": "1.0.4",
@@ -718,9 +718,9 @@
       }
     },
     "node_modules/@flowbuild/engine": {
-      "version": "2.24.2",
-      "resolved": "https://registry.npmjs.org/@flowbuild/engine/-/engine-2.24.2.tgz",
-      "integrity": "sha512-fGJJvg4/FFSlKbWpZ4LVBgTsyz7vpJFtzMeJVXQvFoPBFkBrmcEOEtnhilf4DcjQ9T/auaoXGoeVDY9TiPwl+Q==",
+      "version": "2.24.3",
+      "resolved": "https://registry.npmjs.org/@flowbuild/engine/-/engine-2.24.3.tgz",
+      "integrity": "sha512-RbsRmSirljD+HlIMCPpvGf2WS3VlcAovP0AldWo+Gv2S8UbC9Ooo3SJ4NLJILfBh1RKhC85/MlxazFSpNHxM1Q==",
       "dependencies": {
         "ajv": "8.12.0",
         "ajv-formats": "2.1.1",
@@ -6222,7 +6222,8 @@
     "node_modules/abbrev": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+      "dev": true
     },
     "node_modules/accepts": {
       "version": "1.3.7",
@@ -7048,6 +7049,7 @@
       "version": "3.8.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.8.0.tgz",
       "integrity": "sha512-eXTggHWSooYhq49F2opQhuHWgzucfF2YgODK4e1566GQs5BIfP30B0oenwBJHfWxAs2fyPB1s7Mg949zLf61Yw==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -9140,6 +9142,7 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+      "dev": true,
       "engines": {
         "node": ">=0.8.19"
       }
@@ -9177,7 +9180,8 @@
     "node_modules/ini": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
-      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "dev": true
     },
     "node_modules/interpret": {
       "version": "2.2.0",
@@ -11758,6 +11762,7 @@
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
       "integrity": "sha1-bd0hvSoxQXuScn3Vhfim83YI6+4=",
+      "dev": true,
       "dependencies": {
         "abbrev": "1"
       },
@@ -15912,7 +15917,8 @@
     "node_modules/signal-exit": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "dev": true
     },
     "node_modules/signale": {
       "version": "1.4.0",
@@ -16862,6 +16868,7 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-4.0.2.tgz",
       "integrity": "sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg==",
+      "dev": true,
       "dependencies": {
         "imurmurhash": "^0.1.4",
         "signal-exit": "^3.0.7"

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "supertest": "6.3.3"
   },
   "dependencies": {
-    "@flowbuild/engine": "2.24.2",
+    "@flowbuild/engine": "2.24.3",
     "@flowbuild/indexer": "1.0.2",
     "@flowbuild/nodejs-diagram-builder": "1.1.0",
     "@flowbuild/process-tree": "1.0.4",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "migrations": "knex --env ${KNEX_ENV} --knexfile knexfile.js migrate:latest",
     "migrations:local": "knex --env dockerLocal --knexfile knexfile.js migrate:latest",
     "start": "node src/server.js",
-    "watch": "nodemon --inspect=0.0.0.0 src/server.js",
+    "dev": "nodemon src/server.js",
     "get-version": "echo $npm_package_version",
     "release": "semantic-release",
     "export": "node ./scripts/export.js",
@@ -29,7 +29,7 @@
     "supertest": "6.3.3"
   },
   "dependencies": {
-    "@flowbuild/engine": "2.22.2",
+    "@flowbuild/engine": "2.24.2",
     "@flowbuild/indexer": "1.0.2",
     "@flowbuild/nodejs-diagram-builder": "1.1.0",
     "@flowbuild/process-tree": "1.0.4",
@@ -48,14 +48,14 @@
     "ajv-formats": "2.1.1",
     "amqplib": "0.10.3",
     "async-mqtt": "2.6.3",
-    "axios": "1.3.3",
+    "axios": "1.3.4",
     "dotenv": "16.0.3",
     "grpc-client-promise-wrapper": "1.0.5",
     "grpc-reflection-js": "0.1.2",
-    "jsrsasign": "10.6.1",
+    "jsrsasign": "10.7.0",
     "knex": "2.4.2",
     "koa": "2.14.1",
-    "koa-bodyparser": "4.3.0",
+    "koa-bodyparser": "4.4.0",
     "koa-compose": "4.1.0",
     "koa-helmet": "6.1.0",
     "koa-jwt": "4.0.4",
@@ -66,14 +66,14 @@
     "koa2-cors": "2.0.6",
     "lodash": "4.17.21",
     "nanoid": "3.3.4",
-    "newrelic": "9.10.2",
-    "npm": "9.6.0",
-    "pg": "8.9.0",
+    "newrelic": "9.13.0",
+    "npm": "9.6.2",
+    "pg": "8.10.0",
     "raw-body": "2.5.2",
     "swagger-ui-dist": "4.17.0",
     "uuid": "8.3.2",
     "winston": "3.8.2",
-    "ws": "8.12.1"
+    "ws": "8.13.0"
   },
   "keywords": [],
   "author": "FDTE-DSD",
@@ -84,6 +84,10 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/flow-build/workflow.git"
+  },
+  "nodemonConfig": {
+    "ext": "js",
+    "ignore": ["**/samples/**"] 
   },
   "homepage": "https://github.com/flow-build/workflow#readme"
 }

--- a/src/controllers/cockpit/activityManager.js
+++ b/src/controllers/cockpit/activityManager.js
@@ -1,0 +1,49 @@
+const { getEngine, getCockpit } = require("../../engine");
+const { logger } = require("../../utils/logger");
+
+const expire = async (ctx, next) => {
+  logger.verbose("Cockpit ActivityManager expire");
+  
+  const amid = ctx.params.id;
+  const actor_data = ctx.state.actor_data;
+  
+  const engine = getEngine()
+
+  const am = await engine.fetchActivityManager(amid, actor_data)
+  if(!am) {
+    ctx.status = 404;
+    ctx.body = {
+      message: "activity manager not found"
+    }
+    return next()
+  }
+
+  if(['completed', 'interrupted'].includes(am.activity_status)) {
+    ctx.status = 409;
+    ctx.body = {
+      message: "activity manager cannot be expired",
+      current_status: am.activity_status
+    }
+    return next()
+  }
+
+  const cockpit = getCockpit();
+  
+
+  try {
+    cockpit.expireActivityManager(amid, actor_data);
+    ctx.status = 200;
+    ctx.body = {
+      message: "Expire command submitted, check process history for current status"
+    };
+  } catch (e) {
+    ctx.status = 400;
+    ctx.body = { message: `Failed at ${e.message}`, error: e };
+  }
+  
+  return next();
+}
+  
+module.exports = {
+  expire,
+}

--- a/src/controllers/cockpit/process.js
+++ b/src/controllers/cockpit/process.js
@@ -251,7 +251,6 @@ const expireProcess = async (ctx, next) => {
 
   const cockpit = getCockpit();
   const process = await cockpit.fetchProcess(process_id);
-  console.log(process)
   if(!process) {
     ctx.status = 404;
     ctx.body = { message: "Process not found" }

--- a/src/routers/cockpitRouter.js
+++ b/src/routers/cockpitRouter.js
@@ -10,6 +10,7 @@ const wv = require("../validators/workflow");
 const workflowCtrl = require("../controllers/workflow");
 const cp = require("../controllers/cockpit/process");
 const pt = require('../controllers/cockpit/processTree');
+const cam = require("../controllers/cockpit/activityManager")
 const { getNodes, fetchNode } = require("../controllers/cockpit/nodes")
 
 module.exports = (opts = {}) => {
@@ -48,15 +49,21 @@ module.exports = (opts = {}) => {
   processes.post("/:id/state/run", validateUUID, cp.runPendingProcess);
   processes.post("/:id/set/:state_id", validateUUID, cp.transferProcessState);
   processes.get("/:id/tree", validateUUID, pt.getProcessTree);
+  processes.post("/:id/expire", validateUUID, cp.expireProcess);
   
   const nodes = new Router();
   nodes.prefix("/nodes");
   nodes.get('/', getNodes)
   nodes.post("/", cockpitValidator.validateFetchNodeSchema, fetchNode)
 
+  const activityManager = new Router();
+  activityManager.prefix("/activities");
+  activityManager.post("/:id/expire", validateUUID, cam.expire)
+
   router.use(processes.routes());
   router.use(workflows.routes());
   router.use(nodes.routes());
+  router.use(activityManager.routes());
 
   return router;
 };

--- a/src/samples/blueprints/timersConflicting.js
+++ b/src/samples/blueprints/timersConflicting.js
@@ -1,0 +1,48 @@
+module.exports = {
+  name: "timerConflicting",
+  description: "Process that expires before the userTask timer run out",
+  blueprint_spec: {
+    requirements: ["core"],
+    prepare: [],
+    nodes: [
+      {
+        id: "START",
+        type: "Start",
+        name: "Start process",
+        next: "USERTASK",
+        parameters: {
+          input_schema: {},
+          timeout: 5
+        },
+        lane_id: "1",
+      },
+      {
+        id: "USERTASK",
+        type: "UserTask",
+        name: "UserTask with higher duration",
+        next: "END",
+        lane_id: "1",
+        parameters: {
+          action: "do something",
+          input: {},
+          timeout: 10
+        },
+      },
+      {
+        id: "END",
+        type: "Finish",
+        name: "Finish process",
+        next: null,
+        lane_id: "1",
+      },
+    ],
+    lanes: [
+      {
+        id: "1",
+        name: "the_only_lane",
+        rule: { $js: "() => true" },
+      },
+    ],
+    environment: {},
+  },
+};

--- a/src/samples/blueprints/timersConflicting2.js
+++ b/src/samples/blueprints/timersConflicting2.js
@@ -1,36 +1,37 @@
 module.exports = {
-  name: "timer_process",
-  description: "timer task workflow",
+  name: "timerConflicting2",
+  description: "Process that expires before the intermediate timer run out",
   blueprint_spec: {
     requirements: ["core"],
     prepare: [],
     nodes: [
       {
-        id: "1",
+        id: "START",
         type: "Start",
-        name: "Start node",
-        next: "2",
+        name: "Start process",
+        next: "TIMER",
         parameters: {
           input_schema: {},
+          timeout: 5
         },
         lane_id: "1",
       },
       {
-        id: "2",
+        id: "TIMER",
         type: "SystemTask",
         category: "timer",
-        name: "Timer node",
-        next: "3",
+        name: "Timer node with higher duration than process",
+        next: "END",
         lane_id: "1",
         parameters: {
           input: {},
-          timeout: 30,
+          duration: "PT10S",
         },
       },
       {
-        id: "3",
+        id: "END",
         type: "Finish",
-        name: "Finish node",
+        name: "Finish process",
         next: null,
         lane_id: "1",
       },
@@ -39,7 +40,7 @@ module.exports = {
       {
         id: "1",
         name: "the_only_lane",
-        rule: ["fn", ["&", "args"], true],
+        rule: { $js: "() => true" },
       },
     ],
     environment: {},

--- a/src/samples/blueprints/timersDueDate.js
+++ b/src/samples/blueprints/timersDueDate.js
@@ -1,0 +1,83 @@
+module.exports = {
+  name: "timersDueDate",
+  description: "Sample implementation of timers using dueDate notation",
+  blueprint_spec: {
+    requirements: ["core"],
+    prepare: [],
+    nodes: [
+      {
+        id: "START",
+        type: "Start",
+        name: "Start node",
+        next: "CONFIG",
+        parameters: {
+          input_schema: {},
+        },
+        lane_id: "1",
+      },
+      {
+        id: "CONFIG",
+        name: "Put dates in bag, date 2 needs to be later than date1",
+        next: "TIMER",
+        type: "SystemTask",
+        lane_id: "1",
+        category: "setToBag",
+        parameters: {
+          input: {
+            date1: {
+              $js: "() => { const curDate = new Date(); return new Date(curDate.getTime() + 5 * 1000) };",
+            },
+            date2: {
+              $js: "() => { const curDate = new Date(); return new Date(curDate.getTime() + 10 * 1000) };",
+            },
+          },
+        },
+      },
+      {
+        id: "TIMER",
+        type: "SystemTask",
+        category: "timer",
+        name: "Intermediate Event Timer with dueDate notation & $ref",
+        next: "USERTASK",
+        lane_id: "1",
+        parameters: {
+          input: {},
+          dueDate: { $ref: "bag.date1" },
+        },
+      },
+      {
+        id: "USERTASK",
+        type: "UserTask",
+        name: "User Task with boundary event, duration notation & $ref",
+        next: "END",
+        lane_id: "1",
+        parameters: {
+          action: "do something",
+          input: {},
+        },
+        events: [
+          {
+            family: "target",
+            category: "timer",
+            dueDate: { $ref: "bag.date2" },
+          },
+        ],
+      },
+      {
+        id: "END",
+        type: "Finish",
+        name: "Finish node",
+        next: null,
+        lane_id: "1",
+      },
+    ],
+    lanes: [
+      {
+        id: "1",
+        name: "the_only_lane",
+        rule: { $js: "() => true" },
+      },
+    ],
+    environment: {},
+  },
+};

--- a/src/samples/blueprints/timersDuration.js
+++ b/src/samples/blueprints/timersDuration.js
@@ -1,0 +1,78 @@
+module.exports = {
+  name: "timersDuration",
+  description: "Sample implementation of timers using duration notation",
+  blueprint_spec: {
+    requirements: ["core"],
+    prepare: [],
+    nodes: [
+      {
+        id: "START",
+        type: "Start",
+        name: "Start node",
+        next: "CONFIG",
+        parameters: {
+          input_schema: {},
+        },
+        lane_id: "1",
+      },
+      {
+        id: "CONFIG",
+        name: "Set DueDate",
+        next: "TIMER",
+        type: "SystemTask",
+        lane_id: "1",
+        category: "setToBag",
+        parameters: {
+          input: {
+            date1: "PT6S",
+          },
+        },
+      },
+      {
+        id: "TIMER",
+        type: "SystemTask",
+        category: "timer",
+        name: "Intermediate Event Timer with duration notation",
+        next: "USERTASK",
+        lane_id: "1",
+        parameters: {
+          input: {},
+          duration: "PT4S",
+        },
+      },
+      {
+        id: "USERTASK",
+        type: "UserTask",
+        name: "User Task with boundary event, duration notation & $ref",
+        next: "END",
+        lane_id: "1",
+        parameters: {
+          action: "do something",
+          input: {},
+        },
+        events: [
+          {
+            family: "target",
+            category: "timer",
+            duration: { $ref: "bag.date1" },
+          },
+        ],
+      },
+      {
+        id: "END",
+        type: "Finish",
+        name: "Finish node",
+        next: null,
+        lane_id: "1",
+      },
+    ],
+    lanes: [
+      {
+        id: "1",
+        name: "the_only_lane",
+        rule: { $js: "() => true" },
+      },
+    ],
+    environment: {},
+  },
+};

--- a/src/samples/blueprints/timersDurationProcess.js
+++ b/src/samples/blueprints/timersDurationProcess.js
@@ -1,0 +1,47 @@
+module.exports = {
+  name: "timersDurationProcess",
+  description: "Sample implementation of a process with expiration using duration notation",
+  blueprint_spec: {
+    requirements: ["core"],
+    prepare: [],
+    nodes: [
+      {
+        id: "START",
+        type: "Start",
+        name: "Start process with expiration",
+        next: "USERTASK",
+        parameters: {
+          input_schema: {},
+          duration: "PT10S"
+        },
+        lane_id: "1",
+      },
+      {
+        id: "USERTASK",
+        type: "UserTask",
+        name: "User Task just to keep the process waiting until expiration",
+        next: "END",
+        lane_id: "1",
+        parameters: {
+          action: "just wait",
+          input: {},
+        },
+      },
+      {
+        id: "END",
+        type: "Finish",
+        name: "Finish process",
+        next: null,
+        lane_id: "1",
+      },
+    ],
+    lanes: [
+      {
+        id: "1",
+        name: "the_only_lane",
+        rule: ["fn", ["&", "args"], true],
+      },
+    ],
+    environment: {},
+  },
+};

--- a/src/samples/blueprints/timersTimeout.js
+++ b/src/samples/blueprints/timersTimeout.js
@@ -1,0 +1,59 @@
+module.exports = {
+  name: "timersTimeout",
+  description: "Sample implementation of timers using timeout notation",
+  blueprint_spec: {
+    requirements: ["core"],
+    prepare: [],
+    nodes: [
+      {
+        id: "START",
+        type: "Start",
+        name: "Start process",
+        next: "TIMER",
+        parameters: {
+          input_schema: {},
+        },
+        lane_id: "1",
+      },
+      {
+        id: "TIMER",
+        type: "SystemTask",
+        category: "timer",
+        name: "Intermediate Event Timer with timeout notation",
+        next: "USERTASK",
+        lane_id: "1",
+        parameters: {
+          input: {},
+          timeout: 5,
+        },
+      },
+      {
+        id: "USERTASK",
+        type: "UserTask",
+        name: "User Task with timeout notation",
+        next: "END",
+        lane_id: "1",
+        parameters: {
+          action: "do something",
+          timeout: 6,
+          input: {},
+        },
+      },
+      {
+        id: "END",
+        type: "Finish",
+        name: "Finish process",
+        next: null,
+        lane_id: "1",
+      },
+    ],
+    lanes: [
+      {
+        id: "1",
+        name: "the_only_lane",
+        rule: ["fn", ["&", "args"], true],
+      },
+    ],
+    environment: {},
+  },
+};

--- a/src/samples/blueprints/timersTimeoutProcess.js
+++ b/src/samples/blueprints/timersTimeoutProcess.js
@@ -1,0 +1,47 @@
+module.exports = {
+  name: "timersTimeoutProcess",
+  description: "Sample implementation of a process with expiration using timeout notation",
+  blueprint_spec: {
+    requirements: ["core"],
+    prepare: [],
+    nodes: [
+      {
+        id: "START",
+        type: "Start",
+        name: "Start process with expiration",
+        next: "USERTASK",
+        parameters: {
+          input_schema: {},
+          timeout: 10
+        },
+        lane_id: "1",
+      },
+      {
+        id: "USERTASK",
+        type: "UserTask",
+        name: "User Task just to keep the process waiting until expiration",
+        next: "END",
+        lane_id: "1",
+        parameters: {
+          action: "just wait",
+          input: {},
+        },
+      },
+      {
+        id: "END",
+        type: "Finish",
+        name: "Finish process",
+        next: null,
+        lane_id: "1",
+      },
+    ],
+    lanes: [
+      {
+        id: "1",
+        name: "the_only_lane",
+        rule: ["fn", ["&", "args"], true],
+      },
+    ],
+    environment: {},
+  },
+};

--- a/src/validators/schemas/nodes.js
+++ b/src/validators/schemas/nodes.js
@@ -6,6 +6,8 @@ const nodeSchema = {
         type: "object",
         properties: {
           input_schema: { type: "object" },
+          timeout: { type: "integer" },
+          duration: { type: "string" }
         },
       },
     },
@@ -163,8 +165,7 @@ const categorySchema = {
       },
       input: { type: "object" },
     },
-    required: ["timeout", "input"],
-    additionalProperties: false,
+    required: ["input"]
   },
   startprocess: {
     type: "object",


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Adds to the router the following routes
1. cockpit/processes/:id/expire
2. cockpit/activities/:id/expire

It also updates the engine to version 2.24.x. This new version enables 2 new ways to declare timers:
1. dueDate: receives a date (recommended the usage of a a javascript Date to calculate the dueDate.
2. duration: uses an [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) notation to declare duration. This should avoid confusion between seconds and milliseconds and ease the declaration of long-timers (hours, days)

Those declaration options are available to start nodes, timer nodes, and user tasks. Please notice that user task notation is very different from the usual notation.

Those changes enable the possibility for timers to be managed externally thru a Timer Worker using bullMQ to store timers.
(the final implementation will happen in a future PR, and with the current environment variables the engine should run as usual)

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/fdte-dsd/community/contributors/dev/guide/release_notes.md
-->
```release-note
Adds new routes and new node notations, but everything should be retro-compatible.
```

**Additional documentation e.g., usage docs, etc.**:
```docs
Check several new blueprint samples that shows the different alternatives to describe timers, using dueDate and duration properties.
```
